### PR TITLE
Avoid conflict with stdbool.h

### DIFF
--- a/include/tonc_types.h
+++ b/include/tonc_types.h
@@ -185,8 +185,10 @@ typedef struct { u32 data[16]; } TILE8;
 
 
 #ifndef __cplusplus
+#ifndef __bool_true_false_are_defined
 //! Boolean type
 typedef enum { false, true } bool;
+#endif
 #endif
 
 #ifndef BOOL


### PR DESCRIPTION
I recently ran into an error when both `stdbool.h` and `tonc.h` were included in the same source file.
```
/opt/devkitpro/libtonc/include/tonc_types.h:189:16: error: expected identifier before numeric constant
  189 | typedef enum { false, true } bool;
      |                ^~~~~
```

This commit fixes it by checking for a standard define. :)