### PR TITLE
fix typo in tonc_oam scale function

### DIFF
--- a/include/tonc_oam.h
+++ b/include/tonc_oam.h
@@ -149,7 +149,7 @@ INLINE void obj_aff_identity(OBJ_AFFINE *oaff)
 INLINE void obj_aff_scale(OBJ_AFFINE *oaff, FIXED sx, FIXED sy)
 {
 	oaff->pa= sx;	oaff->pb= 0;
-	oaff->pb= 0;	oaff->pd= sy;
+	oaff->pc= 0;	oaff->pd= sy;
 }
 
 INLINE void obj_aff_shearx(OBJ_AFFINE *oaff, FIXED hx)


### PR DESCRIPTION
I was skimming through the tonc gba library to see how the developer implemented affine scaling, and I noticed that, in the affine transform scaling function, pb is assigned the value zero twice, while pc is never reassigned. Looks like a bug to me, please advise.

Maybe no one has noticed this issue before, but if one were to leave a stale value sitting in the pc field, one might end up with an unexpected result here :)