### PR TITLE
fix incorrect 32-bit read of 16-bit register

### DIFF
--- a/asm/tonc_isr_master.s
+++ b/asm/tonc_isr_master.s
@@ -51,7 +51,7 @@ BEGIN_FUNC_ARM(isr_master, CSEC_IWRAM)
 
 	@ --- If we're here, we have an isr ---
 
-	ldr		r3, [r0, #8]			@ Read IME 
+	ldrh	r3, [r0, #8]			@ Read IME 
 	strb	r0, [r0, #8]			@ Clear IME
 	bic		r2, ip, r2
 	strh	r2, [r0]				@ Clear current irq in IE


### PR DESCRIPTION
this code has a bug where it reads 32 bit value from IME, which is a 16 bit reg. this can cause open bus. 

IME is a 16 bit register and shouldn't be read from using ldr. Prevents possibly unwanted open bus behavior.