### PR TITLE
fix: solve "section conflict" GCC error with attribute macros

### DIFF
--- a/include/tonc_types.h
+++ b/include/tonc_types.h
@@ -46,10 +46,10 @@
 
 
 //! Put variable in IWRAM (default).
-#define IWRAM_DATA __attribute__((section(".iwram")))
+#define IWRAM_DATA __attribute__((section(".iwram_data")))
 
 //! Put variable in EWRAM.
-#define EWRAM_DATA __attribute__((section(".ewram")))
+#define EWRAM_DATA __attribute__((section(".ewram_data")))
 
 //! Put <b>non</b>-initialized variable in EWRAM.
 #define  EWRAM_BSS __attribute__((section(".sbss")))


### PR DESCRIPTION
This is the exact same fix as https://github.com/devkitPro/libgba/pull/9.