### PR TITLE
align dst calculation in bmp16_drawg_b1cos with bmp16_drawg_b1cts.

### DIFF
--- a/src/tte/bmp16_drawg_b1cs.c
+++ b/src/tte/bmp16_drawg_b1cs.c
@@ -83,7 +83,7 @@ void bmp16_drawg_b1cos(uint gid)
 			for(ix=0; ix<8; ix++)
 				dstL[ix]= ((raw>>=1)&1) ? ink : paper;
 
-			dstL += dstP;
+			dstL += dstP/2;
 		}
 		srcL += srcP;
 	}


### PR DESCRIPTION
Otherwise text printed in bmp16 format with this plotter is broken.